### PR TITLE
Dodanie ignorowania katalogu rsconnect generowanego do uzycia shinyapps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 WizualizacjaDanych2018.Rproj
+**/rsconnect/


### PR DESCRIPTION
Uprzejmie proszę o zaakceptowanie mojej zmiany dotyczącej ignorowania katalogu _rsconnect_ generowanego przez _RStudio_ podczas wrzucania aplikacji _Shiny_ na serwer.

Zauważyłem, że część studentów nie dodaje tego katalogu do swojego pliku _.gitignore_, a zawiera on jedynie konfigurację.